### PR TITLE
[Fix]: Router-outlet no muestra el contenido.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,3 @@
 <app-navigation-bar>
-  <router-outlet></router-outlet>
 </app-navigation-bar>
+<router-outlet></router-outlet>


### PR DESCRIPTION
Se reparó el problema que causaba que el router-outlet no rederizara su contenido actual.